### PR TITLE
revert to 2.3.1 version - error on ways refs handling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Cayetano Benavent "cayetano.benavent@geographica.gs"
 # Environment
 ENV PGROUTING_VERSION 2.5.1
 ENV CGAL_VERSION 4.9
-ENV OSM2PGR_VERSION 2.3.2
+ENV OSM2PGR_VERSION 2.3.1
 
 # Sources
 ADD https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz $ROOTDIR/src/


### PR DESCRIPTION
Revert to 2.3.1 until this PR would be merged:
https://github.com/pgRouting/osm2pgrouting/pull/197